### PR TITLE
Exclude musl archive for Fedora build

### DIFF
--- a/pycharm-community/pycharm-community.spec
+++ b/pycharm-community/pycharm-community.spec
@@ -23,7 +23,7 @@
 
 Name:    pycharm-community
 Version: 2025.2.1.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Intelligent Python IDE - Community
 License: Apache-2.0
 URL:     https://www.jetbrains.com/%{appname}/


### PR DESCRIPTION
Make sure to select the correct archive for the Fedora build.

Currently the logic in the specfile selects the musl archive, which
ships `libjvm.so` linked against `libc.musl-x86_64.so.1`, which is not
available on Fedora. That leads to an error when starting PyCharm.

Close #10
